### PR TITLE
Tinypilot Janus integration (1/?)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,3 +101,4 @@ janus_conf_template:
   janus.transport.http.jcfg: janus.transport.http.jcfg
   janus.transport.pfunix.jcfg: janus.transport.pfunix.jcfg
   janus.transport.websockets.jcfg: janus.transport.websockets.jcfg
+  janus.plugin.ustreamer.jcfg: janus.plugin.ustreamer.jcfg

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -8,7 +8,6 @@
   ansible.builtin.file:
     path: "{{ janus_workspace_dir }}"
     state: directory
-    mode: "770"
     recurse: true
     
 - name: Install libnice

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -72,6 +72,19 @@
     chdir: "{{ janus_build_dir }}"
   when: janus_upgrade_available
 
+# Allow Janus C header files to be included when compiling third-party plugins.
+- name: Symlink Janus C header files to the C include path
+  file:
+    src: "{{ janus_install_dir }}/include/janus"
+    dest: /usr/local/include/janus
+    state: link
+
+# We're unable to build the uStreamer Janus plugin because the include statement
+# references the wrong file path.
+# TODO: Create a PR to patch this bug in the janus-gateway repo.
+- name: Patch plugin.h file to successfully include refcount.h file
+  command: sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' "{{ janus_install_dir }}/include/janus/plugins/plugin.h"
+
 - name: Set installed version facts
   ansible.builtin.set_fact:
     janus_installed_versions:  

--- a/templates/janus.plugin.ustreamer.jcfg
+++ b/templates/janus.plugin.ustreamer.jcfg
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+memsink: {
+	object = "{{ ustreamer_h264_sink | default("janus::ustreamer::h264") }}"
+}


### PR DESCRIPTION
This PR is part of https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168

This PR adds the least possible changes needed to reliably install the Janus Gateway on a device running TinyPilot.

I've deliberately maintained the style of the current ansible role to keep these changes in scope of the [original task](https://github.com/tiny-pilot/ansible-role-tinypilot/issues/168). However, I suggest we revise the design of this ansible role (in a follow-up PR) with the goal of either purging config files/variables we don't need or making the role more customizable to skip the parts we don't need.

### Changes
1. Removed the folder permissions of the main `workspace/` folder (where all the dependency git repos are cloned into) because git recognizes the change and aborts during a git pull (after the role has run at least once).
1. [Symlinked the Janus folder into the `/usr/local/include/` folder](https://github.com/tiny-pilot/ansible-role-janus-gateway/blob/55dc03b4b2f12d18c1cd67e82987272baf0c4da0/tasks/janus.yml#L75-L80) so that other third-party plugins can compile using the Janus C header files. Note that I used `/usr/local/include/` instead of `/usr/include/` because I seems that the latter is reserved for packages installed via a package manager (I'm struggling to find where I read this 🤔).
1. [Patch an `include` statement in a Janus header file](https://github.com/tiny-pilot/ansible-role-janus-gateway/blob/55dc03b4b2f12d18c1cd67e82987272baf0c4da0/tasks/janus.yml#L82-L86) to allow uStreamer to compile its Janus plugin. I'm not sure whose responsibility it is to fix this and if it affects other Janus plugins too. I assume it's a bug in [janus-gateway](https://github.com/meetecho/janus-gateway), but I couldn't find an open issue on it. I'm happy to file a bug report on it.

---

You can test the entire "TinyPilot Janus integration" via the following throwaway PR: https://github.com/tiny-pilot/tinypilot/pull/937

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-janus-gateway/1)
<!-- Reviewable:end -->
