### PR TITLE
Fix workspace folder permissions to avoid git detecting them as changes.

### DIFF
--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -8,6 +8,7 @@
   ansible.builtin.file:
     path: "{{ janus_workspace_dir }}"
     state: directory
+    mode: "770"
     recurse: true
 
 - name: Install libnice

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -9,7 +9,6 @@
     path: "{{ janus_workspace_dir }}"
     state: directory
     mode: "770"
-    recurse: true
 
 - name: Install libnice
   import_tasks: libnice.yml

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -8,7 +8,6 @@
   ansible.builtin.file:
     path: "{{ janus_workspace_dir }}"
     state: directory
-    mode: "770"
     recurse: true
 
 - name: Install libnice


### PR DESCRIPTION
This PR <s>removes the specified file permissions of the main workspace folder</s> **removes the recursive workspace folder permissions** (where all the dependency git repos are cloned into).

This change is needed to avoid the dependency git repos from detecting the permission change and failing on subsequent git pulls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-janus-gateway/4)
<!-- Reviewable:end -->
