### PR TITLE
Execute ldconfig to reindex shared libraries after installing them

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,9 @@
 
 - name: reindex shared libraries
   become: true
-  ansible.builtin.command:
-    cmd: ldconfig
+  # Deliberately don't use the FQDN ansible.builtin.command because it doesn't
+  # work with Ansible 2.x: https://github.com/ansible/ansible/issues/71817
+  command: ldconfig
 
 - name: restart janus service
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,10 @@
 ---
 # handlers file for ansible-role-janus-gateway
 
+- name: reindex shared libraries
+  become: true
+  ansible.builtin.command: ldcofig
+
 - name: restart janus service
   become: true
   ansible.builtin.systemd:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,8 @@
 
 - name: reindex shared libraries
   become: true
-  ansible.builtin.command: ldcofig
+  ansible.builtin.command:
+    cmd: ldcofig
 
 - name: restart janus service
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 - name: reindex shared libraries
   become: true
   ansible.builtin.command:
-    cmd: ldcofig
+    cmd: ldconfig
 
 - name: restart janus service
   become: true

--- a/tasks/janus.yml
+++ b/tasks/janus.yml
@@ -71,6 +71,8 @@
     cmd: make install
     chdir: "{{ janus_build_dir }}"
   when: janus_upgrade_available
+  notify:
+    - reindex shared libraries
 
 # Allow Janus C header files to be included when compiling third-party plugins.
 - name: Symlink Janus C header files to the C include path

--- a/tasks/libnice.yml
+++ b/tasks/libnice.yml
@@ -38,3 +38,5 @@
   when: janus_upgrade_available
   environment:
     PATH: "{{ janus_workspace_dir }}/venv/bin:{{ ansible_env.PATH }}"
+  notify:
+    - reindex shared libraries

--- a/tasks/libsrtp.yml
+++ b/tasks/libsrtp.yml
@@ -32,3 +32,5 @@
     cmd: make install
     chdir: "{{ janus_libsrtp_build_dir }}"
   when: janus_upgrade_available
+  notify:
+    - reindex shared libraries

--- a/tasks/libwebsockets.yml
+++ b/tasks/libwebsockets.yml
@@ -24,3 +24,5 @@
     cmd: make install
     chdir: "{{ janus_libwebsockets_build_dir }}"
   when: janus_upgrade_available
+  notify:
+    - reindex shared libraries

--- a/tasks/usrsctp.yml
+++ b/tasks/usrsctp.yml
@@ -30,3 +30,5 @@
     cmd: make install
     chdir: "{{ janus_usrsctp_build_dir }}"
   when: janus_upgrade_available
+  notify:
+    - reindex shared libraries


### PR DESCRIPTION
Without this, Janus fails to load the right shared libraries. See: https://github.com/tiny-pilot/tinypilot/issues/952#issuecomment-1087600274

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-janus-gateway/6)
<!-- Reviewable:end -->
