### PR TITLE
Add websocket ansible variables.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,9 @@ janus_api_secret: null
 janus_token_auth_secret: null
 janus_admin_secret: null
 
+janus_ws_ip: '0.0.0.0'
+janus_ws_port: 8188
+
 janus_conf_var:
   janus:
     plugins_folder: "{{ janus_install_dir }}/lib/janus/plugins"

--- a/templates/janus.transport.websockets.jcfg
+++ b/templates/janus.transport.websockets.jcfg
@@ -10,9 +10,9 @@ general: {
 	#pingpong_timeout = 10			# After how many seconds of not getting a PONG, a timeout should be detected
 
 	ws = true						# Whether to enable the WebSockets API
-	ws_port = 8188					# WebSockets server port
+	ws_port = {{ janus_ws_port }}	# WebSockets server port
 	#ws_interface = "eth0"			# Whether we should bind this server to a specific interface only
-	#ws_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address only
+	ws_ip = "{{ janus_ws_ip }}"		# Whether we should bind this server to a specific IP address only
 	#ws_unix = "/run/ws.sock"		# Use WebSocket server over UNIX socket instead of TCP
 	wss = false						# Whether to enable secure WebSockets
 	#wss_port = 8989				# WebSockets server secure port, if enabled


### PR DESCRIPTION
Part of https://github.com/tiny-pilot/ansible-role-tinypilot-pro/issues/101

This PR adds two ansible variables, namely:
- `janus_ws_ip`
- `janus_ws_port`

This is needed in order to dynamically customize the Janus WebSockets config file and bind the WebSocket server to a specific IP. The default is `0.0.0.0:8188`.

Strictly speaking, the new `janus_ws_port` variable is not needed, but I thought it would be nice to also specify the port.

Note: These flat variable names go against the current nested style of this repo. The problem is that if we do decide to nest these variables ([for example, like this](https://github.com/tiny-pilot/ansible-role-janus-gateway/compare/master...tiny-pilot:websocket-vars-legacy?expand=1)), then when we make use of this role and want to change a single nested value, we'll also need to redefine all other nested values. [I've tracked the flattening of ansible variable here](https://github.com/tiny-pilot/ansible-role-janus-gateway/issues/7).

Part of the reason why I think these variables are nested is to avoid variable naming conflicts between plugins/transports, but the same can be achieved using (very-) verbose flat variable names (which I haven't done in this PR). This PR doesn't consider the existence of similarly named plugins/transports that might cause a naming conflict. Depending on which variable naming direction we take, we should address naming conflicts separately and refactor this repo accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ansible-role-janus-gateway/8)
<!-- Reviewable:end -->
